### PR TITLE
Fix bug where followUserFollowers wasn't checking limits

### DIFF
--- a/index.js
+++ b/index.js
@@ -549,6 +549,7 @@ const Instauto = async (db, browser, options) => {
           }
 
           await sleep(20000);
+          await throttle();
         }
       } catch (err) {
         logger.error(`Failed to process follower ${follower}`, err);


### PR DESCRIPTION
Hello, I was using this library and I think I found a small bug: `maxFollowsPerHour` and `maxFollowsPerDay` where not being checked. 

After digging a little I discovered that the function `throttle()` was being called only at the begging of the function `followUserFollowers()` [L477](https://github.com/mifi/instauto/blob/e65ec1613f8e3c8ccfabbbe5e87908084037384c/index.js#L477). But if you look a little further there is a `for` [L504](https://github.com/mifi/instauto/blob/e65ec1613f8e3c8ccfabbbe5e87908084037384c/index.js#L504) where the "user following thing" is done. So I added another call to `throttle()` at the end of the loop where the condition calls `followCurrentUser(follower)`. That way the max limits are checked every time after a new user is followed.
Hope I was clear.