### PR TITLE
Introduce filter for username

### DIFF
--- a/example.js
+++ b/example.js
@@ -31,6 +31,9 @@ const options = {
   // Don't follow users who have more people following them than this:
   followUserMinFollowing: null,
 
+  // Filter user to follow if their username has a match for at least a string:
+  followUserWithUsernameMatching: null,
+
   // NOTE: The dontUnfollowUntilTimeElapsed option is ONLY for the unfollowNonMutualFollowers function
   // This specifies the time during which the bot should not touch users that it has previously followed (in milliseconds)
   // After this time has passed, it will be able to unfollow them again.

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 
 const assert = require('assert');
 const fs = require('fs-extra');
+const { flatMap } = require('lodash');
 const { join } = require('path');
 const UserAgent = require('user-agents');
 const JSONDB = require('./db');
@@ -44,6 +45,8 @@ const Instauto = async (db, browser, options) => {
     followUserMaxFollowing = null,
     followUserMinFollowers = null,
     followUserMinFollowing = null,
+
+    followUserWithUsernameMatching = null,
 
     dontUnfollowUntilTimeElapsed = 3 * 24 * 60 * 60 * 1000,
 
@@ -584,6 +587,8 @@ const Instauto = async (db, browser, options) => {
           (followUserRatioMin != null && ratio < followUserRatioMin)
         ) {
           logger.log('User has too many followers compared to follows or opposite, skipping');
+        } else if (followUserWithUsernameMatching != null && followUserWithUsernameMatching.find(v => str.includes(v)) === undefined) { 
+          logger.log('User username doesn\'t contain any of the pattern provided, skipping');
         } else {
           await followCurrentUser(follower);
           numFollowedForThisUser += 1;

--- a/index.js
+++ b/index.js
@@ -2,7 +2,6 @@
 
 const assert = require('assert');
 const fs = require('fs-extra');
-const { flatMap } = require('lodash');
 const { join } = require('path');
 const UserAgent = require('user-agents');
 const JSONDB = require('./db');

--- a/index.js
+++ b/index.js
@@ -587,7 +587,7 @@ const Instauto = async (db, browser, options) => {
           (followUserRatioMin != null && ratio < followUserRatioMin)
         ) {
           logger.log('User has too many followers compared to follows or opposite, skipping');
-        } else if (followUserWithUsernameMatching != null && followUserWithUsernameMatching.find(v => str.includes(v)) === undefined) { 
+        } else if (followUserWithUsernameMatching != null && followUserWithUsernameMatching.find(v => follower.includes(v)) === undefined) {
           logger.log('User username doesn\'t contain any of the pattern provided, skipping');
         } else {
           await followCurrentUser(follower);


### PR DESCRIPTION
Hey @mifi first of all very good job for your bot!
I was playing with that and I see there was room for an extra feature, basically a filter that checks if the username of the user contains a partial from an array of strings.

As you can imagine is just enough to set

```js
followUserWithUsernameMatching: ['nice', 'car']
```

And in this way the script will skip all the user that does not contains in the username the keyword `nice` or `car`.