### PR TITLE
Updated findUnfollow function with selector

### DIFF
--- a/index.js
+++ b/index.js
@@ -308,6 +308,9 @@ const Instauto = async (db, browser, options) => {
 
     const elementHandles3 = await page.$x("//header//button[*//span[@aria-label='Following']]");
     if (elementHandles3.length > 0) return elementHandles3[0];
+    
+    const elementHandles4 = await page.$x("//header//button[*//*[name()='svg'][@aria-label='Following']]");
+    if (elementHandles4.length > 0) return elementHandles4[0];
 
     return undefined;
   }


### PR DESCRIPTION
Looks like instagram changed unfollow button from span to svg element that broke "unfollow" automation, find a way to fix it with new selector without changing original logic.