### PR TITLE
Add manually followed accounts to the database

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -327,6 +327,11 @@ const Instauto = async (db, browser, options) => {
     if (!elementHandle) {
       if (await findUnfollowButton()) {
         logger.log('We are already following this user');
+
+        // Already following this user manually, add it to the database.
+        const entry = { username, manual: true, time: new Date().getTime() };
+        await addPrevFollowedUser(entry);
+
         await sleep(5000);
         return;
       }


### PR DESCRIPTION
Add manually added accounts to the followed.json database to prevent checking this account over and over when in fact we are already following them anyway.

Much like https://github.com/mifi/instauto/issues/33#issuecomment-723217177 but for users that are succesfully followed manually.

I marked them as `manual:true` so if we feel the need to do something with them later (e.g. don't auto unfollow manually followed accounts) we can simply do this because the data will be already available.