### PR TITLE
return unfollow mutual count

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1031,7 +1031,7 @@ const Instauto = async (db, browser, options) => {
       return followsMe === false;
     }
 
-    await safelyUnfollowUserList(allFollowingGenerator, limit, condition);
+    return safelyUnfollowUserList(allFollowingGenerator, limit, condition);
   }
 
   async function unfollowAllUnknown({ limit } = {}) {

--- a/src/index.js
+++ b/src/index.js
@@ -1048,7 +1048,7 @@ const Instauto = async (db, browser, options) => {
       return true;
     }
 
-    await safelyUnfollowUserList(unfollowUsersGenerator, limit, condition);
+    return safelyUnfollowUserList(unfollowUsersGenerator, limit, condition);
   }
 
   async function unfollowOldFollowed({ ageInDays, limit } = {}) {


### PR DESCRIPTION
Return the number of unfollows for unfollowNonMutualFollowers()

So you can do something like this:
```
    let unfollowedCount = await instauto.unfollowOldFollowed({ ageInDays: dontUnfollowUntilDaysElapsed, limit: options.maxFollowsPerDay * (6 / 10) });
    if (unfollowedCount > 0) await instauto.sleep(10 * 60 * 1000);

    unfollowedMutualCount += await instauto.unfollowNonMutualFollowers({ limit: options.maxFollowsPerDay * (1 / 10) });
    if (unfollowedMutualCount > 0) await instauto.sleep(10 * 60 * 1000);
    unfollowedCount += unfollowedMutualCount;

    await instauto.followUsersFollowers({
        usersToFollowFollowersOf: options.usersToFollowFollowersOf,
        maxFollowsTotal: options.maxFollowsPerDay - unfollowedCount, // unfollowOldFollowed() + unfollowNonMutualFollowers()
        skipPrivate: true,
        enableLikeImages: true,
        likeImagesMax: options.maxLikesPerUser,
    });
```