### PR TITLE
shouldLikeImage function

### DIFF
--- a/example.js
+++ b/example.js
@@ -53,7 +53,7 @@ const options = {
   }, */
 
   // Custom logic filter for liking media
-  shouldLikeImg: null,
+  shouldLikeMedia: null,
 
   // NOTE: The dontUnfollowUntilTimeElapsed option is ONLY for the unfollowNonMutualFollowers function
   // This specifies the time during which the bot should not touch users that it has previously followed (in milliseconds)

--- a/example.js
+++ b/example.js
@@ -52,6 +52,9 @@ const options = {
     return true;
   }, */
 
+  // Custom logic filter for liking media
+  shouldLikeImg: null,
+
   // NOTE: The dontUnfollowUntilTimeElapsed option is ONLY for the unfollowNonMutualFollowers function
   // This specifies the time during which the bot should not touch users that it has previously followed (in milliseconds)
   // After this time has passed, it will be able to unfollow them again.

--- a/src/index.js
+++ b/src/index.js
@@ -556,10 +556,10 @@ const Instauto = async (db, browser, options) => {
       if (!foundClickable) throw new Error('Like button not found');
 
       if (!dryRunIn) {
-        const img = dialog.querySelectorAll('._aagt')[0];
+        const img = dialog.querySelector('img[srcset]');
         const imageSrc = img.src;
         const imageAlt = img.alt;
-        const imageDesc = dialog.querySelectorAll('._a9zs')[0].textContent;
+        const imageDesc = dialog.querySelector('[role=menuitem] h2 ~ div').textContent;
 
         console.log(image);
 

--- a/src/index.js
+++ b/src/index.js
@@ -46,7 +46,7 @@ const Instauto = async (db, browser, options) => {
     followUserMinFollowing = null,
 
     shouldFollowUser = null,
-    shouldLikeImg = null,
+    shouldLikeMedia = null,
 
     dontUnfollowUntilTimeElapsed = 3 * 24 * 60 * 60 * 1000,
 
@@ -556,14 +556,24 @@ const Instauto = async (db, browser, options) => {
       if (!foundClickable) throw new Error('Like button not found');
 
       if (!dryRunIn) {
-        const img = dialog.querySelector('img[srcset]');
-        const imageSrc = img.src;
-        const imageAlt = img.alt;
-        const imageDesc = dialog.querySelector('[role=menuitem] h2 ~ div').textContent;
+        const presentation = dialog.querySelector('article[role=presentation]');
+        const img = presentation.querySelector('img[alt^="Photo by "]');
+        const video = presentation.querySelector('video[type="video/mp4"]');
+        const mediaDesc = presentation.querySelector('[role=menuitem] h2 ~ div').textContent;
+        let mediaType; let imageSrc; let imageAlt; let videoPoster; let videoSrc;
+        if (img) {
+          mediaType = 'image';
+          imageSrc = img.src;
+          imageAlt = img.alt;
+        } else if (video) {
+          mediaType = 'video';
+          videoPoster = video.poster;
+          videoSrc = video.src;
+        } else {
+          logger.warn('Could not determin mediaType');
+        }
 
-        console.log(image);
-
-        if (shouldLikeImg !== null && (typeof shouldLikeImg === 'function' && !shouldLikeImg({ username, imageSrc, imageAlt, imageDesc }) === true)) {
+        if (shouldLikeMedia !== null && (typeof shouldLikeMedia === 'function' && !shouldLikeMedia({ username, mediaType, mediaDesc, imageSrc, imageAlt, videoPoster, videoSrc }) === true)) {
           logger.log(`Custom follow logic returned false for ${image.href}, skipping`);
         } else {
           foundClickable.click();

--- a/src/index.js
+++ b/src/index.js
@@ -522,35 +522,6 @@ const Instauto = async (db, browser, options) => {
       return;
     }
 
-    function likeImage() {
-      if (shouldLikeMediaIn !== null && (typeof shouldLikeMediaIn === 'function')) {
-        const presentation = dialog.querySelector('article[role=presentation]');
-        const img = presentation.querySelector('img[alt^="Photo by "]');
-        const video = presentation.querySelector('video[type="video/mp4"]');
-        const mediaDesc = presentation.querySelector('[role=menuitem] h2 ~ div').textContent;
-        let mediaType; let src; let alt; let poster;
-        if (img) {
-          mediaType = 'image';
-          ({ src } = img);
-          ({ alt } = img);
-        } else if (video) {
-          mediaType = 'video';
-          ({ poster } = video);
-          ({ src } = video);
-        } else {
-          instautoLog('Could not determin mediaType');
-        }
-
-        if (!shouldLikeMediaIn({ mediaType, mediaDesc, src, alt, poster })) {
-          instautoLog(`shouldLikeMedia returned false for ${image.href}, skipping`);
-          return;
-        }
-      }
-
-      foundClickable.click();
-      window.instautoOnImageLiked(image.href);
-    }
-
     for (const image of images) {
       image.click();
 
@@ -583,6 +554,38 @@ const Instauto = async (db, browser, options) => {
       const foundClickable = findClickableParent(likeButtonChild);
 
       if (!foundClickable) throw new Error('Like button not found');
+
+      const instautoLog2 = instautoLog;
+
+      // eslint-disable-next-line no-inner-declarations
+      function likeImage() {
+        if (shouldLikeMediaIn !== null && (typeof shouldLikeMediaIn === 'function')) {
+          const presentation = dialog.querySelector('article[role=presentation]');
+          const img = presentation.querySelector('img[alt^="Photo by "]');
+          const video = presentation.querySelector('video[type="video/mp4"]');
+          const mediaDesc = presentation.querySelector('[role=menuitem] h2 ~ div').textContent;
+          let mediaType; let src; let alt; let poster;
+          if (img) {
+            mediaType = 'image';
+            ({ src } = img);
+            ({ alt } = img);
+          } else if (video) {
+            mediaType = 'video';
+            ({ poster } = video);
+            ({ src } = video);
+          } else {
+            instautoLog2('Could not determin mediaType');
+          }
+
+          if (!shouldLikeMediaIn({ mediaType, mediaDesc, src, alt, poster })) {
+            instautoLog2(`shouldLikeMedia returned false for ${image.href}, skipping`);
+            return;
+          }
+        }
+
+        foundClickable.click();
+        window.instautoOnImageLiked(image.href);
+      }
 
       if (!dryRunIn) {
         likeImage();

--- a/src/index.js
+++ b/src/index.js
@@ -46,6 +46,7 @@ const Instauto = async (db, browser, options) => {
     followUserMinFollowing = null,
 
     shouldFollowUser = null,
+    shouldLikeImg = null,
 
     dontUnfollowUntilTimeElapsed = 3 * 24 * 60 * 60 * 1000,
 
@@ -555,9 +556,20 @@ const Instauto = async (db, browser, options) => {
       if (!foundClickable) throw new Error('Like button not found');
 
       if (!dryRunIn) {
-        foundClickable.click();
+        const img = dialog.querySelectorAll('._aagt')[0];
+        const imageSrc = img.src;
+        const imageAlt = img.alt;
+        const imageDesc = dialog.querySelectorAll('._a9zs')[0].textContent;
 
-        window.instautoOnImageLiked(image.href);
+        console.log(image);
+
+        if (shouldLikeImg !== null && (typeof shouldLikeImg === 'function' && !shouldLikeImg({ username, imageSrc, imageAlt, imageDesc }) === true)) {
+          logger.log(`Custom follow logic returned false for ${image.href}, skipping`);
+        } else {
+          foundClickable.click();
+
+          window.instautoOnImageLiked(image.href);
+        }
       }
 
       await window.instautoSleep(3000);


### PR DESCRIPTION
I would love to introduce a shouldLikeImg function similar to the shouldFollowUser feature. This would return a boolean for liking photos and be null by default. 
 
Instagram has a straightforward image recognition in the alt tag of the photo, such as "Photo by ... in .... May be an image of nature and waterfall."

The custom function logic then can do these types of checks:
- Check if the alt tag includes a keyword, for example 'nature'. 
- Check the photo description for specific keywords, the language, and/or use something like meaningcloud to see if the sentiment of the text is not negative. 
- And/or you can use the image URL to do further image recognition using a service like Clarifai. 

#114 
