### PR TITLE
Bug: Added `navigateToUserAndGetData` function to return values of `Instauto`  function

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1172,6 +1172,7 @@ const Instauto = async (db, browser, options) => {
     getPage,
     followUsersFollowers: processUsersFollowers,
     doesUserFollowMe,
+    navigateToUserAndGetData,
   };
 };
 


### PR DESCRIPTION
              PS: Created a new pull request because my code editor messed up my previous request
# Summary

Problem faced: Can't fetch **userId** of a username to pass into **getFollowersOrFollowing** function.

Solution: Added **navigateToUserAndGetData** to the returning object of  **Instauto**

# Detailed

 I was trying to fetch the list of following and followers of myself. In order to do that, **getFollowersOrFollowing** requires you to pass the **userId**. But there function required to fetch **userId** and other user details weren't exposed through the object returned by **Instauto**.